### PR TITLE
Remove the Google analysis script

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,11 +1,1 @@
-<!-- Here you can add your Google Analytics Tracking code. If you do so, do not
-forget to set the include_analytics attribute to true on the _config.yml file -->
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-97612757-1"></script>
-<script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
 
-    gtag('config', 'UA-97612757-1');
-</script>


### PR DESCRIPTION
Hi Haoran,

I am Liangchen Luo. I just noticed that you used my specialized jekyll scheme for your homepage.

I am happy that you like my work. But I have to say that this behavior bordered me a lot. It polluted my Google analysis thread with unacceptable bad links and disturb the traffic analysis.

PLEASE remove the whole content at this page IMMEDIATELY and upload your revised website to stop using my analysis id: https://github.com/ranery/ranery.github.io/blob/master/_includes/analytics.html

Besides, I sincerely suggest you change the builder name from my GitHub nickname to your own name.

Finally, as I had been maintaining this scheme for over 4 years and made great efforts on it, I would happy if you may not exclude the copyright information.
A sentence at the footnote similar to this is ok: The Jekyll theme was created by [Luolc](https://github.com/Luolc).

Sincerely,
Liangchen Luo